### PR TITLE
Fix keyword argument 2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ach (0.6.2)
+    ach (0.6.3)
       holidays (>= 3.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ach (0.6.0)
+    ach (0.6.2)
       holidays (>= 3.1)
 
 GEM
@@ -14,7 +14,7 @@ GEM
     autotest (5.0.0)
       minitest-autotest (~> 1.0)
     diff-lcs (1.3)
-    holidays (8.4.1)
+    holidays (8.6.0)
     minitest (5.14.1)
     minitest-autotest (1.1.1)
       minitest-server (~> 1.0)
@@ -51,4 +51,4 @@ DEPENDENCIES
   rspec (~> 3.2)
 
 BUNDLED WITH
-   2.2.2
+   2.3.26

--- a/lib/ach/ach_file.rb
+++ b/lib/ach/ach_file.rb
@@ -79,7 +79,7 @@ module ACH
 
     def parse_fixed data
       # replace with a space to preserve the record-lengths
-      encoded_data = data.encode(Encoding.find('ASCII'),{:invalid => :replace, :undef => :replace, :replace => ' '})
+      encoded_data = data.encode(Encoding.find('ASCII'), **{:invalid => :replace, :undef => :replace, :replace => ' '})
       parse encoded_data.scan(/.{94}/).join("\n")
     end
 

--- a/lib/ach/version.rb
+++ b/lib/ach/version.rb
@@ -1,3 +1,3 @@
 module ACH
-  VERSION = '0.6.2'.freeze
+  VERSION = '0.6.3'.freeze
 end

--- a/spec/ach/parse_spec.rb
+++ b/spec/ach/parse_spec.rb
@@ -21,6 +21,7 @@ describe "Parse" do
 
     it "should parse return/notification of change file" do
       fake_current_datetime = Date.new(2012, 10, 15)
+      expected_datetime = DateTime.new(2012, 10, 15, 19, 32)
       allow(Date).to receive(:today).and_return(fake_current_datetime)
 
       ach = ACH::ACHFile.new(@data)
@@ -41,7 +42,7 @@ describe "Parse" do
       expect(bh.full_company_identification).to eq("1412345678")
       expect(bh.standard_entry_class_code).to eq('COR')
       expect(bh.company_entry_description).to eq("DESCRIPT")
-      expect(bh.company_descriptive_date).to eq('SD1932')
+      expect(bh.company_descriptive_date).to eq(expected_datetime)
       expect(bh.effective_entry_date).to eq(Date.parse('121015'))
       expect(bh.originating_dfi_identification).to eq("99222222")
 


### PR DESCRIPTION
Noticed that there was still one place where the Ruby 2.7 keyword argument deprecation was being raised.

Running bundle exec rspec spec/ach/parse_spec.rb no longer raises deprecation errors.

Also noticed that the specs were failing and fixed that point of failure. 